### PR TITLE
fix --target when used from command-line

### DIFF
--- a/src/Bubleify.js
+++ b/src/Bubleify.js
@@ -25,6 +25,7 @@ class Bubleify extends Transform {
     delete options.sourceMap;
     delete options.extensions;
     delete options.bubleError;
+    delete options.target._;
 
     return options;
   }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -50,3 +50,12 @@ test('cli with custom extension', (t) => {
 
   testContextQuad5(bProcess, t);
 });
+
+test('cli with target', (t) => {
+  const bProcess = spawn(browserifyCmd, [
+    '-r', `${quadPath}:quad`,
+    '-t', '[', bubleifyPath, '--target', '[', '--ie', '11', ']', ']',
+  ], { shell: true });
+
+  testContextQuad5(bProcess, t);
+});


### PR DESCRIPTION
I was trying to get `--target` working from the CLI, but it kept failing with this sort of error:

```
Error: Unknown environment '_'. Please raise an issue at https://github.com/Rich-Harris/buble/issues while parsing file: /Users/boneskull/projects/garthenweb/bubleify/tests/files/quad.js
    at Object.keys.forEach.environment (/Users/boneskull/projects/garthenweb/bubleify/node_modules/buble/dist/buble.cjs.js:9354:12)
    at Array.forEach (<anonymous>)
    at target (/Users/boneskull/projects/garthenweb/bubleify/node_modules/buble/dist/buble.cjs.js:9351:22)
    at transform (/Users/boneskull/projects/garthenweb/bubleify/node_modules/buble/dist/buble.cjs.js:9413:19)
    at Bubleify._flush (/Users/boneskull/projects/garthenweb/bubleify/lib/Bubleify.js:47:43)
    at Bubleify.prefinish (_stream_transform.js:141:10)
    at Bubleify.emit (events.js:197:13)
    at prefinish (_stream_writable.js:635:14)
    at finishMaybe (_stream_writable.js:643:5)
    at endWritable (_stream_writable.js:663:3)
```

This error can be triggered via e.g.:

```shell
$ browserify entry.js -t [ bubleify --target [ --ie 11 ] ]
```

For whatever reason, the `target` context has an empty array prop `_` (which ostensibly means "positional arguments" in minimist).  The result is a `target` prop in the options of `{_: [], ie: '11'}`, and Buble does not like this at all.

This PR removes the unused `_` from the `target` prop of the options sent to Buble and adds a test.



